### PR TITLE
[cm]  Spectral filter example

### DIFF
--- a/examples/example_spectral_filter.py
+++ b/examples/example_spectral_filter.py
@@ -84,7 +84,7 @@ class SpectralFilterWrapper(WaveformToWaveformBase):
                  io_n_ch: int = 2,
                  n_fft: int = 2048,
                  hop_len: int = 512,
-                 fade_n_samples: int = 32,
+                 fade_n_samples: int = 256,  # Cross-fade for half the hop_len to ensure no buzzing in the wet audio
                  use_debug_mode: bool = True) -> None:
         """
         Creates a modified WaveformToWaveformBase wrapper that can be used to create spectral neural audio effects.

--- a/examples/example_spectral_filter.py
+++ b/examples/example_spectral_filter.py
@@ -84,7 +84,7 @@ class SpectralFilterWrapper(WaveformToWaveformBase):
                  io_n_ch: int = 2,
                  n_fft: int = 2048,
                  hop_len: int = 512,
-                 fade_n_samples: int = 256,  # Cross-fade for half the hop_len to ensure no buzzing in the wet audio
+                 fade_n_samples: int = 384,  # Cross-fade for 3/4 of the hop_len to ensure no buzzing in the wet audio
                  use_debug_mode: bool = True) -> None:
         """
         Creates a modified WaveformToWaveformBase wrapper that can be used to create spectral neural audio effects.
@@ -152,9 +152,9 @@ class SpectralFilterWrapper(WaveformToWaveformBase):
 
     def get_neutone_parameters(self) -> List[NeutoneParameter]:
         return [
-            NeutoneParameter("center", "center frequency of the filter", default_value=0.5),
-            NeutoneParameter("width", "width of the filter", default_value=0.4),
-            NeutoneParameter("amount", "spectral attenuation amount", default_value=0.75),
+            NeutoneParameter("center", "center frequency of the filter", default_value=0.3),
+            NeutoneParameter("width", "width of the filter", default_value=0.5),
+            NeutoneParameter("amount", "spectral attenuation amount", default_value=0.9),
         ]
 
     @tr.jit.export

--- a/examples/example_spectral_filter.py
+++ b/examples/example_spectral_filter.py
@@ -122,7 +122,7 @@ class SpectralFilterWrapper(WaveformToWaveformBase):
             log.info(f"STFT delay = {self.calc_min_delay_samples()}")
 
     def get_model_name(self) -> str:
-        return "spectral-distortion"
+        return "spectral.filter"
 
     def get_model_authors(self) -> List[str]:
         return ["Christopher Mitcheltree"]

--- a/examples/example_spectral_filter.py
+++ b/examples/example_spectral_filter.py
@@ -7,7 +7,6 @@ from typing import Dict, List
 import torch as tr
 import torch.nn as nn
 from torch import Tensor
-from torchaudio.transforms import MelScale
 
 from neutone_sdk import WaveformToWaveformBase, NeutoneParameter
 from neutone_sdk.realtime_stft import RealtimeSTFT
@@ -183,9 +182,9 @@ class SpectralFilterWrapper(WaveformToWaveformBase):
 
     def do_forward_pass(self, x: Tensor, params: Dict[str, Tensor]) -> Tensor:
         center, width, amount = params["center"], params["width"], params["amount"]
-        x = self.stft.audio_to_spec(x)  # Convert the audio to a spectrogram
+        x = self.stft.audio_to_spec(x)  # Convert the audio to a spectrogram (n_ch, n_bins, n_frames)
         x = self.model.forward(x, center, width, amount)  # Apply the spectral filter and receive an altered spectrogram
-        x = self.stft.spec_to_audio(x)  # Convert the filtered spectrogram back to audio
+        x = self.stft.spec_to_audio(x)  # Convert the filtered spectrogram back to audio (n_ch, n_samples)
         return x
 
 

--- a/examples/example_spectral_filter.py
+++ b/examples/example_spectral_filter.py
@@ -1,0 +1,202 @@
+import logging
+import os
+import pathlib
+from argparse import ArgumentParser
+from typing import Dict, List
+
+import torch as tr
+import torch.nn as nn
+from torch import Tensor
+
+from neutone_sdk import WaveformToWaveformBase, NeutoneParameter
+from neutone_sdk.realtime_stft import RealtimeSTFT
+from neutone_sdk.utils import save_neutone_model
+
+logging.basicConfig()
+log = logging.getLogger(__name__)
+log.setLevel(level=os.environ.get("LOGLEVEL", "INFO"))
+
+
+class SpectralFilter(nn.Module):
+    def __init__(self) -> None:
+        """
+        Creates a spectral notch filter, where the bandwidth of the filter also changes as the center frequency changes.
+        """
+        super().__init__()
+        self.half_constant = tr.tensor(0.5)
+
+    def _map_0to1_val_to_log_bin_idx(self, val: Tensor, max_bin: int) -> int:
+        """
+        Maps a float tensor between [0.0, 1.0] to an integer between [0, max_bins] with the assumption that the
+        bin indices follow a logarithmic spacing.
+        """
+        idx = (tr.exp(val) - 1.0) / (tr.e - 1.0) * max_bin
+        idx = int(tr.clip(tr.round(idx), 0, max_bin))
+        return idx
+
+    def forward(self, x: Tensor, center: Tensor, width: Tensor, amount: Tensor) -> Tensor:
+        """
+        Filters a positive valued log-magnitude spectrogram using a rectangle with controllable center, width,
+        and amount of attenuation.
+
+        Args:
+            x: a log-magnitude spectrogram with shape (n_ch, n_bins, n_frames)
+            center: 1D control value between [0.0, 1.0] for the center frequency of the filter.
+            width: 1D control value between [0.0, 1.0] for the bandwidth of the filter.
+            amount: 1D control value between [0.0, 1.0] for the amount of attenuation.
+        """
+        if amount == 0.0:
+            return x
+        n_bins = x.size(1)  # Figure out how many bins we have to work with
+        center_bin = self._map_0to1_val_to_log_bin_idx(center, n_bins - 1)  # Find the center bin
+        width_n_bins = self._map_0to1_val_to_log_bin_idx(width, n_bins)  # Find the width in no. of bins
+        if width_n_bins == 0:
+            return x
+        # Find the lowest freq bin
+        width_center = self._map_0to1_val_to_log_bin_idx(self.half_constant, width_n_bins)
+        lo_bin_idx = center_bin - width_center
+        lo_bin_idx = max(0, lo_bin_idx)
+        # Find the highest freq bin
+        hi_bin_idx = center_bin + (width_n_bins - width_center)
+        hi_bin_idx = min(n_bins - 1, hi_bin_idx)
+        # Apply filter
+        x[:, lo_bin_idx:hi_bin_idx, :] *= (1.0 - amount)
+        return x
+
+
+class SpectralFilterWrapper(WaveformToWaveformBase):
+    def __init__(self,
+                 spectral_filter_model: nn.Module,
+                 model_io_n_frames: int = 16,
+                 io_n_ch: int = 2,
+                 n_fft: int = 2048,
+                 hop_len: int = 512,
+                 fade_n_samples: int = 32,
+                 use_debug_mode: bool = True) -> None:
+        """
+        Creates a modified WaveformToWaveformBase wrapper that can be used to create spectral neural audio effects.
+        Feel free to use this as a starting point to make your own spectral effects!
+
+        Args:
+            spectral_filter_model: a spectral model, in this example a filter (could be replaced with anything).
+            model_io_n_frames: the number of STFT frames the spectral model expects as input and output.
+            io_n_ch: the number of channels the spectral model expects as input and output (should be 1 or 2).
+            n_fft: n_fft to use for the STFT.
+            hop_len: hop_len in samples to use for the STFT.
+            fade_n_samples: no. of samples to crossfade between output buffers of audio after the inverse STFT. Adds a
+                            slight delay, but prevents clicks and pops in the output audio.
+            use_debug_mode: makes debugging easier, is turned off automatically before the model is exported.
+        """
+        self.io_n_ch = io_n_ch
+        super().__init__(spectral_filter_model, use_debug_mode)
+        self.stft = RealtimeSTFT(
+            model_io_n_frames=model_io_n_frames,
+            io_n_ch=io_n_ch,
+            n_fft=n_fft,
+            hop_len=hop_len,
+            power=1.0,             # Ensures an energy spectrogram
+            logarithmize=True,     # Ensures a log-magnitude spectrogram
+            ensure_pos_spec=True,  # Ensures a positive-valued spectrogram
+            use_phase_info=True,   # Keep the phase information for the inverse STFT
+            fade_n_samples=fade_n_samples,
+            use_debug_mode=use_debug_mode
+        )
+        self.stft.set_buffer_size(self.stft.calc_min_buffer_size())
+        if use_debug_mode:
+            assert 1 <= self.io_n_ch <= 2
+            log.info(f"Supported buffer sizes = {self.get_native_buffer_sizes()}")
+            log.info(f"Supported sample rate = {self.get_native_sample_rates()}")
+            log.info(f"STFT delay = {self.calc_min_delay_samples()}")
+
+    def get_model_name(self) -> str:
+        return "spectral-distortion"
+
+    def get_model_authors(self) -> List[str]:
+        return ["Christopher Mitcheltree"]
+
+    def get_model_short_description(self) -> str:
+        return "Spectral notch filter."
+
+    def get_model_long_description(self) -> str:
+        return "Filters the audio in the spectral domain using a central frequency, bandwidth, and amount. " \
+               "The bandwidth changes as the central frequency changes."
+
+    def get_technical_description(self) -> str:
+        return "Filters the audio in the spectral domain using a central frequency, bandwidth, and amount. " \
+               "The bandwidth changes as the central frequency changes."
+
+    def get_technical_links(self) -> Dict[str, str]:
+        return {}
+
+    def get_tags(self) -> List[str]:
+        return ["spectral", "filter", "notch filter", "stft", "template"]
+
+    def get_model_version(self) -> str:
+        return "1.0.0"
+
+    def is_experimental(self) -> bool:
+        return True
+
+    def get_neutone_parameters(self) -> List[NeutoneParameter]:
+        return [
+            NeutoneParameter("center", "center frequency of the filter", default_value=0.5),
+            NeutoneParameter("width", "width of the filter", default_value=0.5),
+            NeutoneParameter("amount", "spectral attenuation %", default_value=0.6),
+        ]
+
+    @tr.jit.export
+    def is_input_mono(self) -> bool:
+        return self.io_n_ch == 1
+
+    @tr.jit.export
+    def is_output_mono(self) -> bool:
+        return self.io_n_ch == 1
+
+    @tr.jit.export
+    def get_native_sample_rates(self) -> List[int]:
+        # For consistent filtering across different sampling rates, a native sampling rate must be given. Feel free to
+        # change this to your required sampling rate.
+        return [44100]
+
+    @tr.jit.export
+    def get_native_buffer_sizes(self) -> List[int]:
+        return self.stft.calc_supported_buffer_sizes()  # Possible buffer sizes are determined by the STFT parameters
+
+    @tr.jit.export
+    def calc_min_delay_samples(self) -> int:
+        # TODO(cm): make a model specific version of this method?
+        return self.stft.calc_min_delay_samples()  # This is equal to `fade_n_samples`
+
+    def set_model_buffer_size(self, n_samples: int) -> bool:
+        self.stft.set_buffer_size(n_samples)
+        return True
+
+    def reset_model(self) -> bool:
+        self.stft.reset()
+        return True
+
+    def prepare_for_inference(self) -> None:
+        super().prepare_for_inference()
+        # This needs to be done explicitly until we have dedicated wrapper base class for spectral models
+        self.stft.use_debug_mode = False
+        self.stft.eval()
+
+    def do_forward_pass(self, x: Tensor, params: Dict[str, Tensor]) -> Tensor:
+        center, width, amount = params["center"], params["width"], params["amount"]
+        x = self.stft.audio_to_spec(x)  # Convert the audio to a spectrogram
+        x = self.model.forward(x, center, width, amount)  # Apply the spectral filter and receive an altered spectrogram
+        x = self.stft.spec_to_audio(x)  # Convert the filtered spectrogram back to audio
+        return x
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("-o", "--output", default="export_model")
+    args = parser.parse_args()
+    root_dir = pathlib.Path(args.output)
+
+    model = SpectralFilter()
+    wrapper = SpectralFilterWrapper(model)
+    save_neutone_model(
+        wrapper, root_dir, freeze=True, dump_samples=True, submission=True
+    )

--- a/neutone_sdk/core.py
+++ b/neutone_sdk/core.py
@@ -82,6 +82,8 @@ class NeutoneModel(ABC, nn.Module):
             neutone_param.name: default_param_values[idx]
             for idx, neutone_param in enumerate(self.get_neutone_parameters())
         }
+        # This is required for TorchScript typing when there are no Neutone parameters defined
+        self.remapped_params["__torchscript_typing"] = default_param_values[0]
 
     @abstractmethod
     def get_model_name(self) -> str:

--- a/neutone_sdk/realtime_stft.py
+++ b/neutone_sdk/realtime_stft.py
@@ -11,46 +11,49 @@ log = logging.getLogger(__name__)
 log.setLevel(level=os.environ.get("LOGLEVEL", "INFO"))
 
 
+# TODO(cm:) add documentation, for now please see the documentation in `examples/example_spectral_filter.py`
 class RealtimeSTFT(nn.Module):
     def __init__(
         self,
-        model: Optional[nn.Module] = None,
         model_io_n_frames: int = 16,
-        batch_size: int = 1,
+        io_n_ch: int = 2,
         io_n_samples: int = 512,
         n_fft: int = 2048,
         hop_len: int = 512,
         window: Optional[Tensor] = None,
-        spec_diff_mode: bool = False,
-        center: bool = False,
+        center: bool = True,
         power: Optional[float] = 1.0,
         logarithmize: bool = True,
         ensure_pos_spec: bool = True,
         use_phase_info: bool = True,
         fade_n_samples: int = 0,
         eps: float = 1e-8,
+        use_debug_mode: bool = True
     ) -> None:
         super().__init__()
-        assert n_fft % 2 == 0
-        assert (n_fft // 2) % hop_len == 0
-        if window is not None:
-            assert window.shape == (n_fft,)
-        if center:
-            log.warning("STFT is not causal when center=True")
-        assert power is None or power >= 1.0
-        if power is not None and power > 1.0:
-            log.warning(
-                "A power greater than 1.0 probably adds unnecessary "
-                "computational complexity"
-            )
-        assert eps < 1.0
-        self.model = model
+        self.use_debug_mode = use_debug_mode
+        if self.use_debug_mode:
+            assert n_fft % 2 == 0
+            assert (n_fft // 2) % hop_len == 0
+            if window is not None:
+                assert window.shape == (n_fft,)
+            assert center, "Behavior of center=False needs to be debugged, results in artefacts"
+            # if center:
+            #     log.warning("STFT is not causal when center=True")
+            assert power is None or power >= 1.0
+            if power is None and use_phase_info:
+                log.warning("If power=None, `use_phase_info=True` means the imag component is saved, not the angle")
+            if power is not None and power > 1.0:
+                log.warning(
+                    "A power greater than 1.0 probably adds unnecessary "
+                    "computational complexity"
+                )
+            assert fade_n_samples < io_n_samples
         self.model_io_n_frames = model_io_n_frames
-        self.batch_size = batch_size
+        self.io_n_ch = io_n_ch
         self.io_n_samples = io_n_samples
         self.n_fft = n_fft
         self.hop_len = hop_len
-        self.spec_diff_mode = spec_diff_mode
         self.center = center
         self.power = power
         self.logarithmize = logarithmize
@@ -103,31 +106,34 @@ class RealtimeSTFT(nn.Module):
 
     def _set_derived_params(self) -> None:
         self.io_n_frames = self.io_n_samples // self.hop_len
-        assert self.io_n_frames <= self.model_io_n_frames
+        if self.use_debug_mode:
+            assert self.io_n_frames <= self.model_io_n_frames
         self.overlap_n_frames = self.n_fft // 2 // self.hop_len
         self.in_buf_n_frames = (2 * self.overlap_n_frames) + self.io_n_frames - 1
         self.n_bins = (self.n_fft // 2) + 1
         if self.center:
             self.stft_out_shape = (
-                self.batch_size,
+                self.io_n_ch,
                 self.n_bins,
                 (2 * self.overlap_n_frames) + self.io_n_frames,
             )
             self.istft_in_n_frames = self.overlap_n_frames + self.io_n_frames
             self.istft_length = (self.istft_in_n_frames - 1) * self.hop_len
         else:
-            self.stft_out_shape = (self.batch_size, self.n_bins, self.io_n_frames)
+            self.stft_out_shape = (self.io_n_ch, self.n_bins, self.io_n_frames)
             self.istft_in_n_frames = self.io_n_frames
             self.istft_length = self.in_buf_n_frames * self.hop_len
-        assert self.istft_in_n_frames <= self.model_io_n_frames
+        if self.use_debug_mode:
+            assert self.istft_in_n_frames <= self.model_io_n_frames
 
-        self.model_io_shape = (self.batch_size, self.n_bins, self.model_io_n_frames)
+        self.model_io_shape = (self.io_n_ch, self.n_bins, self.model_io_n_frames)
         self.out_buf_n_samples = self.io_n_samples + self.fade_n_samples
-        assert self.out_buf_n_samples <= self.istft_length
+        if self.use_debug_mode:
+            assert self.out_buf_n_samples <= self.istft_length
 
     def _allocate_buffers(self) -> None:
         self.in_buf = tr.full(
-            (self.batch_size, self.in_buf_n_frames * self.hop_len),
+            (self.io_n_ch, self.in_buf_n_frames * self.hop_len),
             self.eps,
         )
 
@@ -140,20 +146,54 @@ class RealtimeSTFT(nn.Module):
         self.phase_buf = tr.zeros(self.model_io_shape)
 
         self.out_frames_buf = tr.full(
-            (self.batch_size, self.n_bins, self.istft_in_n_frames),
+            (self.io_n_ch, self.n_bins, self.istft_in_n_frames),
             self.eps,
             dtype=tr.complex64,
         )
         self.out_buf = tr.full(
-            (self.batch_size, self.out_buf_n_samples),
+            (self.io_n_ch, self.out_buf_n_samples),
             self.eps,
         )
 
+    def _logarithmize_spec(self, spec: Tensor) -> None:
+        tr.clamp(spec, min=self.eps, out=spec)
+        tr.log10(spec, out=spec)
+
+    def _unlogarithmize_spec(self, spec: Tensor) -> None:
+        tr.pow(10, spec, out=spec)  # TODO: memory
+        tr.clamp(spec, min=self.eps, out=spec)
+
+    def _update_mag_or_phase_buffers(
+        self, stft_out_buf: Tensor, frames_buf: Tensor
+    ) -> Tensor:
+        if self.center:
+            # Remove overlap frames we have computed before
+            frames = stft_out_buf[:, :, self.overlap_n_frames :]
+            # Identify frames that are more correct due to missing prev audio
+            fixed_prev_frames = frames[:, :, : -self.io_n_frames]
+            if self.use_debug_mode:
+                assert fixed_prev_frames.size(2) == self.overlap_n_frames
+            # Identify the new frames for the input audio chunk
+            new_frames = frames[:, :, -self.io_n_frames :]
+            # Overwrite previous frames with more correct frames
+            n_fixed_frames = min(self.model_io_n_frames, self.overlap_n_frames)
+            frames_buf[:, :, -n_fixed_frames:] = fixed_prev_frames[
+                :, :, -n_fixed_frames:
+            ]
+        else:
+            new_frames = stft_out_buf[:, :, -self.io_n_frames :]
+
+        # Shift buffer left and insert new frames
+        frames_buf = tr.roll(frames_buf, -self.io_n_frames, dims=2)  # TODO: memory
+        frames_buf[:, :, -self.io_n_frames:] = new_frames
+        return frames_buf
+
     @tr.jit.export
     def set_buffer_size(self, io_n_samples: int) -> None:
-        assert io_n_samples >= self.hop_len
-        assert io_n_samples % self.hop_len == 0
-        assert self.fade_n_samples <= io_n_samples
+        if self.use_debug_mode:
+            assert io_n_samples >= self.hop_len
+            assert io_n_samples % self.hop_len == 0
+            assert self.fade_n_samples <= io_n_samples
         self.io_n_samples = io_n_samples
         self._set_derived_params()
         self._allocate_buffers()
@@ -162,6 +202,17 @@ class RealtimeSTFT(nn.Module):
     @tr.jit.export
     def calc_min_delay_samples(self) -> int:
         return self.fade_n_samples
+
+    @tr.jit.export
+    def reset(self) -> None:
+        self.in_buf.fill_(self.eps)
+        self.stft_mag_buf.fill_(self.eps)
+        self.mag_buf.fill_(self.eps)
+        self.spec_out_buf.fill_(self.eps)
+        self.stft_phase_buf.fill_(0)
+        self.phase_buf.fill_(0)
+        self.out_frames_buf.fill_(self.eps)
+        self.out_buf.fill_(self.eps)
 
     @tr.jit.export
     def calc_min_buffer_size(self) -> int:
@@ -180,46 +231,13 @@ class RealtimeSTFT(nn.Module):
         ]
         return buffer_sizes
 
-    @tr.jit.export
-    def reset(self) -> None:
-        self.in_buf.fill_(self.eps)
-        self.stft_mag_buf.fill_(self.eps)
-        self.mag_buf.fill_(self.eps)
-        self.spec_out_buf.fill_(self.eps)
-        self.stft_phase_buf.fill_(0)
-        self.phase_buf.fill_(0)
-        self.out_frames_buf.fill_(self.eps)
-        self.out_buf.fill_(self.eps)
-
-    def _update_mag_or_phase_buffers(
-        self, stft_out_buf: Tensor, frames_buf: Tensor
-    ) -> Tensor:
-        if self.center:
-            # Remove overlap frames we have computed before
-            frames = stft_out_buf[:, :, self.overlap_n_frames :]
-            # Identify frames that are more correct due to missing prev audio
-            fixed_prev_frames = frames[:, :, : -self.io_n_frames]
-            assert fixed_prev_frames.shape[2] == self.overlap_n_frames
-            # Identify the new frames for the input audio chunk
-            new_frames = frames[:, :, -self.io_n_frames :]
-            # Overwrite previous frames with more correct frames
-            n_fixed_frames = min(self.model_io_n_frames, self.overlap_n_frames)
-            frames_buf[:, :, -n_fixed_frames:] = fixed_prev_frames[
-                :, :, -n_fixed_frames:
-            ]
-        else:
-            new_frames = stft_out_buf[:, :, -self.io_n_frames :]
-
-        # Shift buffer left and insert new frames
-        frames_buf = tr.roll(frames_buf, -self.io_n_frames, dims=2)
-        frames_buf[:, :, -self.io_n_frames :] = new_frames
-        return frames_buf
-
     @tr.jit.ignore
     def audio_to_spec_offline(self, audio: Tensor) -> Tensor:
-        assert audio.shape[0] == self.batch_size
-        assert audio.shape[1] >= self.n_fft
-        assert audio.shape[1] % self.hop_len == 0
+        if self.use_debug_mode:
+            assert audio.size(0) == self.io_n_ch
+            assert audio.size(1) >= self.n_fft
+            assert audio.size(1) % self.hop_len == 0
+        # TODO(cm): allow pad_mode to be selected
         spec = tr.stft(
             audio,
             n_fft=self.n_fft,
@@ -245,9 +263,10 @@ class RealtimeSTFT(nn.Module):
 
     @tr.jit.export
     def audio_to_spec(self, audio: Tensor) -> Tensor:
-        # assert audio.shape == (self.batch_size, self.io_n_samples)
+        if self.use_debug_mode:
+            assert audio.shape == (self.io_n_ch, self.io_n_samples)
         # Shift buffer left and insert audio chunk
-        self.in_buf = tr.roll(self.in_buf, -self.io_n_samples, dims=1)
+        self.in_buf = tr.roll(self.in_buf, -self.io_n_samples, dims=1)  # TODO: memory
         self.in_buf[:, -self.io_n_samples :] = audio
 
         complex_frames = tr.stft(
@@ -288,12 +307,13 @@ class RealtimeSTFT(nn.Module):
 
     @tr.jit.export
     def spec_to_audio(self, spec: Tensor) -> Tensor:
-        # assert spec.shape == self.model_io_shape
+        if self.use_debug_mode:
+            assert spec.shape == self.model_io_shape
         spec = spec[:, :, -self.istft_in_n_frames :]
         if self.use_phase_info:
-            phase = self.phase_buf[:, :, -self.istft_in_n_frames :]
+            phase = self.phase_buf[:, :, -self.istft_in_n_frames:]
         else:
-            phase = self.zero_phase[:, :, -self.istft_in_n_frames :]
+            phase = self.zero_phase[:, :, -self.istft_in_n_frames:]
 
         if self.logarithmize:
             if self.ensure_pos_spec:
@@ -308,6 +328,7 @@ class RealtimeSTFT(nn.Module):
                 tr.pow(spec, 1 / self.power, out=spec)
             tr.polar(spec, phase, out=self.out_frames_buf)
 
+        # TODO(cm): allow pad_mode to be selected
         rec_audio = tr.istft(
             self.out_frames_buf,
             n_fft=self.n_fft,
@@ -316,54 +337,13 @@ class RealtimeSTFT(nn.Module):
             center=self.center,
             length=self.istft_length,
         )
-        rec_audio = rec_audio[:, -self.out_buf_n_samples :]
+        rec_audio = rec_audio[:, -self.out_buf_n_samples:]
         if self.fade_n_samples == 0:
             return rec_audio
 
-        self.out_buf[:, -self.fade_n_samples :] *= self.fade_down
+        self.out_buf[:, -self.fade_n_samples:] *= self.fade_down
         rec_audio[:, : self.fade_n_samples] *= self.fade_up
         rec_audio[:, : self.fade_n_samples] += self.out_buf[:, -self.fade_n_samples :]
         audio_out = rec_audio[:, : self.io_n_samples]
         self.out_buf = rec_audio
         return audio_out
-
-    def _logarithmize_spec(self, spec: Tensor) -> None:
-        tr.clamp(spec, min=self.eps, out=spec)
-        tr.log10(spec, out=spec)
-
-    def _unlogarithmize_spec(self, spec: Tensor) -> None:
-        tr.pow(10, spec, out=spec)
-        tr.clamp(spec, min=self.eps, out=spec)
-
-    @tr.jit.export
-    def flush(self) -> Tensor:
-        # TODO(christhetree): prevent this memory allocation
-        audio_out = tr.full((self.batch_size, self.io_n_samples), self.eps)
-        if self.fade_n_samples > 0:
-            audio_out[:, : self.fade_n_samples] = self.out_buf[
-                :, -self.fade_n_samples :
-            ]
-        # else:
-        #     log.warning('Flushing is not necessary when fade_n_samples == 0')
-        return audio_out
-
-    def forward(self, audio: Tensor, spec_wetdry_ratio: float = 1.0) -> Tensor:
-        with tr.no_grad():
-            dry_spec = self.audio_to_spec(audio)
-            if self.model is None:
-                # TODO(christhetree): eliminate memory allocation here
-                wet_spec = tr.clone(dry_spec)
-            else:
-                wet_spec = self.model(dry_spec)
-
-            if self.spec_diff_mode:
-                tr.sub(dry_spec, wet_spec, out=wet_spec)
-
-            if spec_wetdry_ratio < 1.0:
-                dry_amount = 1.0 - spec_wetdry_ratio
-                wet_spec *= spec_wetdry_ratio
-                dry_spec *= dry_amount
-                wet_spec += dry_spec
-
-            rec_audio = self.spec_to_audio(wet_spec)
-            return rec_audio

--- a/neutone_sdk/sqw.py
+++ b/neutone_sdk/sqw.py
@@ -286,7 +286,8 @@ class SampleQueueWrapper(nn.Module):
     ) -> int:
         # Sample rate
         if model_sr is not None:
-            assert len(self.get_native_sample_rates()) == 0 or model_sr in self.get_native_sample_rates()
+            if self.use_debug_mode:
+                assert len(self.get_native_sample_rates()) == 0 or model_sr in self.get_native_sample_rates()
         else:
             model_sr = self.select_best_model_sr(daw_sr, self.get_native_sample_rates())
 
@@ -299,7 +300,8 @@ class SampleQueueWrapper(nn.Module):
 
         # Buffer size
         if model_bs is not None:
-            assert len(self.get_native_buffer_sizes()) == 0 or model_bs in self.get_native_buffer_sizes()
+            if self.use_debug_mode:
+                assert len(self.get_native_buffer_sizes()) == 0 or model_bs in self.get_native_buffer_sizes()
         else:
             model_bs = self.select_best_model_buffer_size(io_bs, self.get_native_buffer_sizes())
 

--- a/testing/profiling.py
+++ b/testing/profiling.py
@@ -10,7 +10,6 @@ from torch.autograd.profiler import record_function
 from torch.profiler import profile
 from tqdm import tqdm
 
-from examples.example_spectral_filter import SpectralFilter, SpectralFilterWrapper
 from neutone_sdk import WaveformToWaveformBase, NeutoneParameter, SampleQueueWrapper, constants
 from neutone_sdk.utils import model_to_torchscript
 

--- a/testing/profiling.py
+++ b/testing/profiling.py
@@ -10,6 +10,7 @@ from torch.autograd.profiler import record_function
 from torch.profiler import profile
 from tqdm import tqdm
 
+from examples.example_spectral_filter import SpectralFilter, SpectralFilterWrapper
 from neutone_sdk import WaveformToWaveformBase, NeutoneParameter, SampleQueueWrapper, constants
 from neutone_sdk.utils import model_to_torchscript
 


### PR DESCRIPTION
This PR implements a spectral filter that can serve as a template for spectral audio effects.
It also fixes some dynamic memory allocations of the RealtimeSTFT class and refactors it a bit.

I'll add some tests for the STFT class in a separate PR, you can tell it's working correctly if you set all the knobs to zero of the spectral filter and can then hear the exact input audio being passed through successfully without being modified, even though it is being converted to the frequency domain and back again.

@Fyfe93 
cc: @bogdanteleaga 