### PR TITLE
Fix dtype when reading AudioSample and remove NamedTemporaryFile

### DIFF
--- a/neutone_sdk/audio.py
+++ b/neutone_sdk/audio.py
@@ -88,7 +88,7 @@ class AudioSample:
     @classmethod
     def from_bytes(cls, bytes_: bytes) -> Self:
         y, sr = sf.read(io.BytesIO(bytes_), always_2d=True)
-        return cls(tr.from_numpy(y.T), sr)
+        return cls(tr.from_numpy(y.T.astype(np.float32)), sr)
 
     @classmethod
     def from_file(cls, path: str) -> Self:


### PR DESCRIPTION
We found a problem while exporting rave models, apparently soundfile returns double arrays by default.