### PR TITLE
new notebooks + v2 export script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ We open source this SDK so researchers can wrap their own audio models and run t
 - Full clipper distortion model example can be found [here](examples/example_clipper.py).
 - Example of a random overdrive model based on [micro-tcn](https://github.com/csteinmetz1/micro-tcn) can be found [here](examples/example_overdrive-random.py)
 - Notebooks for different models showing the entire workflow from training to exporting it using Neutone
-    - [DDSP](https://colab.research.google.com/drive/15FuafmtGWEyvTOOQbN1AMIQRhGLy23Pg)
-    - [RAVE](https://colab.research.google.com/drive/1hty5Bd7rJJ70hlI-5720sEY3kylNxBIt)
+    - [DDSP Timbre Transfer](https://colab.research.google.com/drive/1yPHU6PRWw1lRWZLUxXimIa6chFQ2JdRW?usp=sharing)
+    - [RAVE Timbre Transfer](https://colab.research.google.com/drive/1qlN6xLvDYrLcAwS8yh2ecmNG_bEKlVI9?usp=sharing)
+    - [TCN FX Emulation](https://colab.research.google.com/drive/1gHZ-AEoYmfmWrjlKpKkK_SW1xzfxD24-?usp=sharing)
 
 ## v1 Release
 


### PR DESCRIPTION
Update notebook links with new ones and export script with one that is compatible with RAVE v2 and v1.
NOTE: chaos knob on new export script directly controls the magnitude of latent noise, and is not a multiplier like the old script.