### PR TITLE
Aggregate param fix

### DIFF
--- a/neutone_sdk/audio.py
+++ b/neutone_sdk/audio.py
@@ -190,7 +190,7 @@ def render_audio_sample(
             params = torchaudio.transforms.Resample(input_sample.sr, preferred_sr)(
                 params
             )
-            params = torch.clamp(params, 0, 1)
+            params = tr.clamp(params, 0, 1)
 
         # padding and chunking parameters to match audio
         padded_params = nn.functional.pad(params, [0, padding_amount], mode="replicate")

--- a/neutone_sdk/wavform_to_wavform.py
+++ b/neutone_sdk/wavform_to_wavform.py
@@ -52,6 +52,7 @@ class WaveformToWaveformBase(NeutoneModel):
         self.params_queue = CircularInplaceTensorQueue(self.MAX_N_PARAMS, 1)
         self.model_in_buffer = tr.zeros((self.in_n_ch, 1))
         self.params_buffer = tr.zeros((self.MAX_N_PARAMS, 1))
+        self.agg_params = tr.zeros((self.MAX_N_PARAMS, 1))
 
     @abstractmethod
     def is_input_mono(self) -> bool:
@@ -170,10 +171,8 @@ class WaveformToWaveformBase(NeutoneModel):
         """
         if self.use_debug_mode:
             assert params.ndim == 2
-        # This prevents memory allocation by re-using the space in the params tensor
-        agg_params = params[:, 0:1]
-        tr.mean(params, dim=1, keepdim=True, out=agg_params)
-        return agg_params
+        tr.mean(params, dim=1, keepdim=True, out=self.agg_params)
+        return self.agg_params
 
     def prepare_for_inference(self) -> None:
         """Prepare the wrapper and model for inference and to be converted to torchscript."""


### PR DESCRIPTION
RAVE models have been sounding funny with the recent SDK, and it seems that aggregate_params was the problem.
torch.mean was using the same tensor for input and output, which causes some weird behaviors as illustrated below:
```
a = torch.Tensor([1,2,3]) # sum should be 6
b = a[0:1]
torch.sum(a, dim=0, keepdim=True, out=b)
a, b # [5,2,3], [5]
```
which throws off the parameter values.
Also, render_audio_sample was referring to torch as torch and not tr (as imported). 