### PR TITLE
Fix a bug with deepcopy by saving and reloading model insted

### DIFF
--- a/neutone_sdk/utils.py
+++ b/neutone_sdk/utils.py
@@ -1,4 +1,5 @@
 import copy
+import io
 import json
 import logging
 import os
@@ -113,7 +114,13 @@ def save_neutone_model(
 
         # We need to keep a copy because some models still don't implement reset
         # properly and when rendering the samples we might create unwanted state.
-        script_copy = copy.deepcopy(script)
+        # 
+        # We used to deepcopy but we found it breaks some models
+        # script_copy = copy.deepcopy(script)
+        buf = io.BytesIO()
+        tr.jit.save(script, buf)
+        buf.seek(0)
+        script_copy = tr.jit.load(buf)
 
         log.info("Extracting metadata...")
         metadata = script.to_metadata()._asdict()


### PR DESCRIPTION
We found out that deepcopy sometimes breaks models in unexpected ways, so this is a workaround fix that should achieve the same result. But I don't think it's ideal, let me know if you have any better ideas @christhetree @hyakuchiki or let's merge it as is.

For example on the DDSP models
```python
(Pdb) sqw.w2w_base.agg_params
tensor([[0.5000],
        [0.5000],
        [0.5000],
        [0.5000]])
(Pdb) script.w2w_base.agg_params
tensor([[0.5000],
        [0.5000],
        [0.5000],
        [0.5000]])
(Pdb) copy.deepcopy(script).w2w_base.agg_params
tensor([0.5000])
```