### PR TITLE
[cm] Adding generic params

### DIFF
--- a/neutone_sdk/parameter.py
+++ b/neutone_sdk/parameter.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from enum import Enum
-from typing import NamedTuple, Dict
+from typing import Dict
 
 logging.basicConfig()
 log = logging.getLogger(__name__)
@@ -10,9 +10,11 @@ log.setLevel(level=os.environ.get("LOGLEVEL", "INFO"))
 
 class NeutoneParameterType(Enum):
     KNOB = "knob"
+    BLOCK_RATE_TENSOR = "block_rate_tensor"
+    AUDIO_RATE_TENSOR = "audio_rate_tensor"
 
 
-class NeutoneParameter(NamedTuple):
+class NeutoneParameter:
     """
     Define a Neutone Parameter that the user can use to control the model.
 
@@ -23,17 +25,35 @@ class NeutoneParameter(NamedTuple):
     as a default in the plugin when no presets are available.
     """
 
-    name: str
-    description: str
-    default_value: float
-    type: NeutoneParameterType = NeutoneParameterType.KNOB
-    used: bool = True
+    def __init__(self,
+                 name: str,
+                 description: str,
+                 dim: int = 1,
+                 default_value: float = 0.0,
+                 is_at_audio_rate: bool = True,
+                 used: bool = True):
+        self.name = name
+        self.description = description
+        self.dim = dim
+        self.default_value = default_value
+        self.is_at_audio_rate = is_at_audio_rate
+        self.used = used
+
+        # Initialize first for torchscript
+        self.type = NeutoneParameterType.BLOCK_RATE_TENSOR
+        if is_at_audio_rate:
+            if dim == 1:
+                self.type = NeutoneParameterType.KNOB
+            else:
+                self.type = NeutoneParameterType.AUDIO_RATE_TENSOR
 
     def to_metadata_dict(self) -> Dict[str, str]:
         return {
             "name": self.name,
             "description": self.description,
-            "type": self.type.value,
-            "used": str(self.used),
+            "dim": str(self.dim),
             "default_value": str(self.default_value),
+            "is_at_audio_rate": str(self.is_at_audio_rate),
+            "used": str(self.used),
+            "type": self.type.value,
         }

--- a/neutone_sdk/utils.py
+++ b/neutone_sdk/utils.py
@@ -16,7 +16,7 @@ from neutone_sdk.audio import (
     get_default_audio_samples,
     render_audio_sample,
 )
-from neutone_sdk.constants import MAX_N_AUDIO_SAMPLES
+from neutone_sdk.constants import MAX_N_AUDIO_SAMPLES, MAX_N_PARAMS
 from neutone_sdk.core import NeutoneModel
 from neutone_sdk.metadata import validate_metadata
 
@@ -168,6 +168,15 @@ def save_neutone_model(
             f"Model delay reported to the DAW for 48000 Hz sampling rate and 512 buffer size: "
             f"{loaded_model.calc_model_delay_samples()}"
         )
+
+        log.info("Testing offline mode...")
+        for input_sample in get_default_audio_samples():
+            offline_sr = input_sample.sr
+            offline_bs = 4096
+            loaded_model.set_daw_sample_rate_and_buffer_size(offline_sr, offline_bs)
+            offline_params = tr.rand((MAX_N_PARAMS, input_sample.audio.size(1)))
+            offline_rendered_sample = loaded_model.forward_offline(input_sample.audio, offline_params)
+            break
 
         if submission:  # Do extra checks
             log.info("Running submission checks...")

--- a/neutone_sdk/utils.py
+++ b/neutone_sdk/utils.py
@@ -176,7 +176,7 @@ def save_neutone_model(
             loaded_model.set_daw_sample_rate_and_buffer_size(offline_sr, offline_bs)
             offline_params = tr.rand((MAX_N_PARAMS, input_sample.audio.size(1)))
             offline_rendered_sample = loaded_model.forward_offline(input_sample.audio, offline_params)
-            break
+            break  # Only test one sample to reduce export time
 
         if submission:  # Do extra checks
             log.info("Running submission checks...")


### PR DESCRIPTION
This PR is no. 2 of 6 PRs that together will make the SDK compatible with most model configurations.

It makes the parameter class generic such that it can support tensor parameters at block rate or audio rate in preparation for future changes.