### PR TITLE
[cm]  4-point cubic hermite resampling

### DIFF
--- a/examples/example_delayed_passthrough.py
+++ b/examples/example_delayed_passthrough.py
@@ -24,8 +24,8 @@ class DelayedPassthroughModel(nn.Module):
 
     def forward(self, x: Tensor) -> Tensor:
         x = tr.cat([self.delay_buf, x], dim=-1)
-        self.delay_buf[:, :] = x[:, -self.delay_n_samples:]
-        x = x[:, :-self.delay_n_samples]
+        self.delay_buf[:, :] = x[:, -self.delay_n_samples :]
+        x = x[:, : -self.delay_n_samples]
         return x
 
 
@@ -104,6 +104,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     root_dir = pathlib.Path(args.output)
 
-    model = DelayedPassthroughModel(delay_n_samples=500)  # Change delay_n_samples to test different scenarios
+    model = DelayedPassthroughModel(
+        delay_n_samples=500
+    )  # Change delay_n_samples to test different scenarios
     wrapper = DelayedPassthroughModelWrapper(model)
     save_neutone_model(wrapper, root_dir, dump_samples=True, submission=True)

--- a/neutone_sdk/constants.py
+++ b/neutone_sdk/constants.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-SDK_VERSION = "1.4.0"
+SDK_VERSION = "1.4.1"
 
 MAX_N_PARAMS = 4
 MAX_N_AUDIO_SAMPLES = 3

--- a/neutone_sdk/sandwich.py
+++ b/neutone_sdk/sandwich.py
@@ -233,10 +233,14 @@ class InplaceLinearResampler(ResampleSandwich):
         if self.use_debug_mode:
             assert self.out_bs >= 2
 
-        self.x_in, self.y0_idx_in, self.y1_idx_in = self.calc_x_and_indices(self.in_bs, self.out_bs)
+        self.x_in, self.y0_idx_in, self.y1_idx_in = self.calc_x_and_indices(
+            self.in_bs, self.out_bs
+        )
         self.y0_in = tr.zeros((self.in_n_ch, self.out_bs))
         self.y1_in = tr.zeros((self.in_n_ch, self.out_bs))
-        self.x_out, self.y0_idx_out, self.y1_idx_out = self.calc_x_and_indices(self.out_bs, self.in_bs)
+        self.x_out, self.y0_idx_out, self.y1_idx_out = self.calc_x_and_indices(
+            self.out_bs, self.in_bs
+        )
         self.y0_out = tr.zeros((self.out_n_ch, self.in_bs))
         self.y1_out = tr.zeros((self.out_n_ch, self.in_bs))
 
@@ -289,7 +293,8 @@ class InplaceLinearResampler(ResampleSandwich):
 
     @staticmethod
     def calc_x_and_indices(in_bs: int, out_bs: int) -> Tuple[Tensor, Tensor, Tensor]:
-        scaling_factor = (in_bs - 1) / (out_bs - 1) + 1e-12  # Prevents floating point errors
+        # Prevents floating point errors
+        scaling_factor = (in_bs - 1) / (out_bs - 1) + 1e-12
         x = tr.arange(0, out_bs) * scaling_factor
         y0_idx = tr.floor(x).to(tr.long)
         y1_idx = y0_idx + 1
@@ -311,14 +316,15 @@ class Inplace4pHermiteResampler(InplaceLinearResampler):
     The 2nd, -2nd, and sometimes -1st samples will be slightly off since this interpolator requires 4 points, but we
     assume a repeated sample when these are not available at the ends rather than adding 2-samples of delay.
     """
+
     def __init__(
-            self,
-            in_n_ch: int,
-            out_n_ch: int,
-            in_sr: int,
-            out_sr: int,
-            in_bs: int,
-            use_debug_mode: bool = True,
+        self,
+        in_n_ch: int,
+        out_n_ch: int,
+        in_sr: int,
+        out_sr: int,
+        in_bs: int,
+        use_debug_mode: bool = True,
     ) -> None:
         # Buffers required for process_in
         self.y_m1_idx_in = None
@@ -352,10 +358,14 @@ class Inplace4pHermiteResampler(InplaceLinearResampler):
         if self.use_debug_mode:
             assert self.out_bs > 4
 
-        self.x_in, self.y0_idx_in, self.y1_idx_in = self.calc_x_and_indices(self.in_bs, self.out_bs)
+        self.x_in, self.y0_idx_in, self.y1_idx_in = self.calc_x_and_indices(
+            self.in_bs, self.out_bs
+        )
         self.y0_in = tr.zeros((self.in_n_ch, self.out_bs))
         self.y1_in = tr.zeros((self.in_n_ch, self.out_bs))
-        self.x_out, self.y0_idx_out, self.y1_idx_out = self.calc_x_and_indices(self.out_bs, self.in_bs)
+        self.x_out, self.y0_idx_out, self.y1_idx_out = self.calc_x_and_indices(
+            self.out_bs, self.in_bs
+        )
         self.y0_out = tr.zeros((self.out_n_ch, self.in_bs))
         self.y1_out = tr.zeros((self.out_n_ch, self.in_bs))
 
@@ -430,7 +440,7 @@ class Inplace4pHermiteResampler(InplaceLinearResampler):
         tr.mul(y1, x, out=y1)
         tr.add(y1, c0, out=y1)
         return y1
-    
+
     def process_in(self, y: Tensor) -> Tensor:
         return self._process_4p_hermite(
             y,
@@ -468,4 +478,3 @@ class Inplace4pHermiteResampler(InplaceLinearResampler):
             self.c2_out,
             self.c3_out,
         )
-    

--- a/neutone_sdk/sandwich.py
+++ b/neutone_sdk/sandwich.py
@@ -2,6 +2,7 @@ import logging
 import math
 import os
 from abc import abstractmethod, ABC
+from typing import Tuple
 
 import torch as tr
 import torch.nn.functional as F
@@ -209,17 +210,17 @@ class InplaceInterpolationResampler(ResampleSandwich):
         self.out_n_ch = out_n_ch
 
         # Buffers required for process_in
-        self.interp_in = None
-        self.floor_in = None
-        self.ceil_in = None
-        self.in_a = None
-        self.in_b = None
+        self.x_in = None
+        self.y0_idx_in = None
+        self.y1_idx_in = None
+        self.y0_in = None
+        self.y1_in = None
         # Buffers required for process_out
-        self.interp_out = None
-        self.floor_out = None
-        self.ceil_out = None
-        self.out_a = None
-        self.out_b = None
+        self.x_out = None
+        self.y0_idx_out = None
+        self.y1_idx_out = None
+        self.y0_out = None
+        self.y1_out = None
 
         super().__init__(in_sr, out_sr, in_bs, use_debug_mode)
 
@@ -231,74 +232,75 @@ class InplaceInterpolationResampler(ResampleSandwich):
         if self.use_debug_mode:
             assert self.out_bs >= 2
 
-        scaling_factor_in = (self.in_bs - 1) / (self.out_bs - 1)
-        interp_in = (
-            tr.tensor([float(_) for _ in range(self.out_bs)]) * scaling_factor_in
-        )
-        floor_in = tr.floor(interp_in).to(tr.long)
-        self.floor_in = tr.clip(
-            floor_in, 0, self.in_bs - 1
-        )  # Prevents floating point errors
-        ceil_in = tr.ceil(interp_in).to(tr.long)
-        self.ceil_in = tr.clip(
-            ceil_in, 0, self.in_bs - 1
-        )  # Prevents floating point errors
-        self.interp_in = tr.clip(
-            interp_in - self.floor_in, 0.0, 1.0
-        )  # Prevents floating point errors
-        self.in_a = tr.zeros((self.in_n_ch, self.out_bs))
-        self.in_b = tr.zeros((self.in_n_ch, self.out_bs))
-
-        scaling_factor_out = (self.out_bs - 1) / (self.in_bs - 1)
-        interp_out = (
-            tr.tensor([float(_) for _ in range(self.in_bs)]) * scaling_factor_out
-        )
-        floor_out = tr.floor(interp_out).to(tr.long)
-        self.floor_out = tr.clip(
-            floor_out, 0, self.out_bs - 1
-        )  # Prevents floating point errors
-        ceil_out = tr.ceil(interp_out).to(tr.long)
-        self.ceil_out = tr.clip(
-            ceil_out, 0, self.out_bs - 1
-        )  # Prevents floating point errors
-        self.interp_out = tr.clip(
-            interp_out - self.floor_out, 0.0, 1.0
-        )  # Prevents floating point errors
-        self.out_a = tr.zeros((self.out_n_ch, self.in_bs))
-        self.out_b = tr.zeros((self.out_n_ch, self.in_bs))
+        self.x_in, self.y0_idx_in, self.y1_idx_in = self.calc_x_and_indices(self.in_bs, self.out_bs)
+        self.y0_in = tr.zeros((self.in_n_ch, self.out_bs))
+        self.y1_in = tr.zeros((self.in_n_ch, self.out_bs))
+        self.x_out, self.y0_idx_out, self.y1_idx_out = self.calc_x_and_indices(self.out_bs, self.in_bs)
+        self.y0_out = tr.zeros((self.out_n_ch, self.in_bs))
+        self.y1_out = tr.zeros((self.out_n_ch, self.in_bs))
 
     def _process(
         self,
-        x: Tensor,
+        y: Tensor,
         n_ch: int,
         in_bs: int,
-        interp_t: Tensor,
-        floor_t: Tensor,
-        ceil_t: Tensor,
-        a_t: Tensor,
-        b_t: Tensor,
+        x: Tensor,
+        y0_idx: Tensor,
+        y1_idx: Tensor,
+        y0: Tensor,
+        y1: Tensor,
     ) -> Tensor:
         if self.use_debug_mode:
-            assert x.shape == (n_ch, in_bs)
+            assert y.shape == (n_ch, in_bs)
         if not self.is_resampling():
-            return x
-        tr.index_select(x, 1, floor_t, out=a_t)
-        tr.index_select(x, 1, ceil_t, out=b_t)
-        tr.sub(b_t, a_t, out=b_t)
-        tr.mul(b_t, interp_t, out=b_t)
-        tr.add(a_t, b_t, out=a_t)
-        return a_t
+            return y
+        tr.index_select(y, dim=1, index=y0_idx, out=y0)
+        tr.index_select(y, dim=1, index=y1_idx, out=y1)
+        tr.sub(y1, y0, out=y1)
+        tr.mul(y1, x, out=y1)
+        tr.add(y0, y1, out=y0)
+        return y0
+
+    # def _process_hermite(
+    #     self,
+    #     y: Tensor,
+    #     n_ch: int,
+    #     in_bs: int,
+    #     x: Tensor,
+    #     y0_idx: Tensor,
+    #     y1_idx: Tensor,
+    #     y2_idx: Tensor,
+    #     y3_idx: Tensor,
+    #     y0: Tensor,
+    #     y1: Tensor,
+    #     y2: Tensor,
+    #     y3: Tensor,
+    # ) -> Tensor:
+    #     if self.use_debug_mode:
+    #         assert y.shape == (n_ch, in_bs)
+    #     if not self.is_resampling():
+    #         return y
+    #     tr.index_select(y, dim=1, index=y0_idx, out=y0)
+    #     tr.index_select(y, dim=1, index=y1_idx, out=y1)
+    #     tr.index_select(y, dim=1, index=y2_idx, out=y2)
+    #     tr.index_select(y, dim=1, index=y3_idx, out=y3)
+    #     c0 = y0
+    #     c1 = 0.5 * tr.sub(y1, y0, out=y1)
+    #     tr.sub(y1, y0, out=y1)
+    #     tr.mul(y1, x, out=y1)
+    #     tr.add(y0, y1, out=y0)
+    #     return y0
 
     def process_in(self, x: Tensor) -> Tensor:
         return self._process(
             x,
             self.in_n_ch,
             self.in_bs,
-            self.interp_in,
-            self.floor_in,
-            self.ceil_in,
-            self.in_a,
-            self.in_b,
+            self.x_in,
+            self.y0_idx_in,
+            self.y1_idx_in,
+            self.y0_in,
+            self.y1_in,
         )
 
     def process_out(self, x: Tensor) -> Tensor:
@@ -306,9 +308,20 @@ class InplaceInterpolationResampler(ResampleSandwich):
             x,
             self.out_n_ch,
             self.out_bs,
-            self.interp_out,
-            self.floor_out,
-            self.ceil_out,
-            self.out_a,
-            self.out_b,
+            self.x_out,
+            self.y0_idx_out,
+            self.y1_idx_out,
+            self.y0_out,
+            self.y1_out,
         )
+
+    @staticmethod
+    def calc_x_and_indices(in_bs: int, out_bs: int) -> Tuple[Tensor, Tensor, Tensor]:
+        scaling_factor = (in_bs - 1) / (out_bs - 1)
+        x = tr.arange(0, out_bs) * scaling_factor
+        y0_idx = tr.floor(x).to(tr.long)
+        y0_idx = tr.clip(y0_idx, 0, in_bs - 1)  # Prevents floating point errors
+        y1_idx = tr.ceil(x).to(tr.long)
+        y1_idx = tr.clip(y1_idx, 0, in_bs - 1)  # Prevents floating point errors
+        x = tr.clip(x - y0_idx, 0.0, 1.0)  # Prevents floating point errors
+        return x, y0_idx, y1_idx

--- a/neutone_sdk/sqw.py
+++ b/neutone_sdk/sqw.py
@@ -11,7 +11,8 @@ from neutone_sdk.constants import DEFAULT_DAW_SR, DEFAULT_DAW_BS
 from neutone_sdk.queues import CircularInplaceTensorQueue
 from neutone_sdk.sandwich import (
     ChannelNormalizerSandwich,
-    InplaceInterpolationResampler,
+    InplaceLinearResampler,
+    Inplace4pHermiteResampler,
 )
 
 logging.basicConfig()
@@ -46,7 +47,7 @@ class SampleQueueWrapper(nn.Module):
             use_debug_mode=use_debug_mode
         )
         # TODO(cm): switch to a more robust resampling method that prevents aliasing
-        self.resample_sandwich = InplaceInterpolationResampler(
+        self.resample_sandwich = Inplace4pHermiteResampler(
             self.in_n_ch,
             self.out_n_ch,
             daw_sr,
@@ -54,7 +55,7 @@ class SampleQueueWrapper(nn.Module):
             daw_bs,
             use_debug_mode=use_debug_mode,
         )
-        self.params_resample_sandwich = InplaceInterpolationResampler(
+        self.params_resample_sandwich = InplaceLinearResampler(
             self.w2w_base.MAX_N_PARAMS,
             self.w2w_base.MAX_N_PARAMS,
             daw_sr,

--- a/neutone_sdk/sqw.py
+++ b/neutone_sdk/sqw.py
@@ -46,8 +46,6 @@ class SampleQueueWrapper(nn.Module):
         self.channel_normalizer = ChannelNormalizerSandwich(
             use_debug_mode=use_debug_mode
         )
-        # TODO(cm): switch to a more robust resampling method that prevents aliasing
-        # self.resample_sandwich = InplaceLinearResampler(
         self.resample_sandwich = Inplace4pHermiteResampler(
             self.in_n_ch,
             self.out_n_ch,

--- a/neutone_sdk/sqw.py
+++ b/neutone_sdk/sqw.py
@@ -47,6 +47,7 @@ class SampleQueueWrapper(nn.Module):
             use_debug_mode=use_debug_mode
         )
         # TODO(cm): switch to a more robust resampling method that prevents aliasing
+        # self.resample_sandwich = InplaceLinearResampler(
         self.resample_sandwich = Inplace4pHermiteResampler(
             self.in_n_ch,
             self.out_n_ch,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "neutone_sdk"
-version = "1.4.0"
+version = "1.4.1"
 description = "SDK for wrapping deep learning models for usage in the Neutone plugin"
 readme = "README.md"
 authors = ["Qosmo <contact@qosmo.jp>"]

--- a/testing/test_profiling.py
+++ b/testing/test_profiling.py
@@ -100,4 +100,11 @@ if __name__ == "__main__":
     model = ProfilingModel()
     wrapper = ProfilingModelWrapper(model)
     sqw = SampleQueueWrapper(wrapper)
-    profile_sqw(sqw)
+    profile_sqw(sqw, daw_sr=44100, n_iters=1000, convert_to_torchscript=False)
+
+
+# profile_sqw(sqw, daw_sr=44100, n_iters=1000, convert_to_torchscript=False)
+#   None: 0.82
+# Linear: 1.32
+#     PT: 3.04
+# Julius: 3.00

--- a/testing/test_profiling.py
+++ b/testing/test_profiling.py
@@ -92,7 +92,7 @@ class ProfilingModelWrapper(WaveformToWaveformBase):
     def do_forward_pass(self, x: Tensor, params: Dict[str, Tensor]) -> Tensor:
         min_val, max_val, gain = params["min"], params["max"], params["gain"]
         x = self.model.forward(x, min_val, max_val, gain)
-        x = x[:, self.get_look_behind_samples():]
+        x = x[:, self.get_look_behind_samples() :]
         return x
 
 

--- a/testing/test_profiling.py
+++ b/testing/test_profiling.py
@@ -92,7 +92,7 @@ class ProfilingModelWrapper(WaveformToWaveformBase):
     def do_forward_pass(self, x: Tensor, params: Dict[str, Tensor]) -> Tensor:
         min_val, max_val, gain = params["min"], params["max"], params["gain"]
         x = self.model.forward(x, min_val, max_val, gain)
-        x = x[:, self.get_look_behind_samples() :]
+        x = x[:, self.get_look_behind_samples():]
         return x
 
 
@@ -105,8 +105,8 @@ if __name__ == "__main__":
 
 
 # profile_sqw(sqw, daw_sr=44100, n_iters=1000, convert_to_torchscript=False)
-#   None: 0.82
-# Linear: 1.32
-#     PT: 3.04
-# Julius: 3.00
-# Hermit: 2.08
+#       None: 0.82
+#     Linear: 1.32
+#         PT: 3.04
+#     Julius: 3.00
+# 4p Hermite: 1.82

--- a/testing/test_profiling.py
+++ b/testing/test_profiling.py
@@ -100,13 +100,4 @@ if __name__ == "__main__":
     model = ProfilingModel()
     wrapper = ProfilingModelWrapper(model)
     sqw = SampleQueueWrapper(wrapper)
-    profile_sqw(sqw, daw_sr=44100, n_iters=1000, convert_to_torchscript=False)
-    # profile_sqw(sqw, daw_sr=44100, n_iters=1000, convert_to_torchscript=True)
-
-
-# profile_sqw(sqw, daw_sr=44100, n_iters=1000, convert_to_torchscript=False)
-#       None: 0.82
-#     Linear: 1.32
-#         PT: 3.04
-#     Julius: 3.00
-# 4p Hermite: 1.82
+    profile_sqw(sqw, daw_sr=48000, n_iters=100, convert_to_torchscript=True)

--- a/testing/test_profiling.py
+++ b/testing/test_profiling.py
@@ -101,6 +101,7 @@ if __name__ == "__main__":
     wrapper = ProfilingModelWrapper(model)
     sqw = SampleQueueWrapper(wrapper)
     profile_sqw(sqw, daw_sr=44100, n_iters=1000, convert_to_torchscript=False)
+    # profile_sqw(sqw, daw_sr=44100, n_iters=1000, convert_to_torchscript=True)
 
 
 # profile_sqw(sqw, daw_sr=44100, n_iters=1000, convert_to_torchscript=False)
@@ -108,3 +109,4 @@ if __name__ == "__main__":
 # Linear: 1.32
 #     PT: 3.04
 # Julius: 3.00
+# Hermit: 2.08

--- a/testing/test_sandwiches.py
+++ b/testing/test_sandwiches.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import os
 import random
 
@@ -72,4 +73,82 @@ def test_linear_resamplers(n_trials: int = 1000, in_n_ch: int = 2, out_n_ch: int
         assert tr.equal(out_linear_inplace[:, [0, -1]], out_audio[:, [0, -1]])
 
 
-test_linear_resamplers()
+def _calc_4p_hermite(x: float, y_m1: float, y0: float, y1: float, y2: float) -> float:
+    # This is super slow, but the fast version has already been implemented and is being tested using this
+    c0 = y0
+    c1 = 0.5 * (y1 - y_m1)
+    c2 = y_m1 - 2.5 * y0 + 2.0 * y1 - 0.5 * y2
+    c3 = 0.5 * (y2 - y_m1) + 1.5 * (y0 - y1)
+    return ((c3 * x + c2) * x + c1) * x + c0
+
+
+def test_4p_hermite_resampler(n_trials: int = 50, in_n_ch: int = 2, out_n_ch: int = 2) -> None:
+    random.seed(42)
+    tr.manual_seed(42)
+    sampling_rates = [16000, 22050, 32000, 44100, 48000, 88200, 96000]
+    buffer_sizes = [64, 128, 256, 512, 1024, 2048]
+
+    resampler = Inplace4pHermiteResampler(in_n_ch, out_n_ch, 48000, 48000, 512)
+
+    for _ in tqdm(range(n_trials)):
+        sr_a = random.choice(sampling_rates)
+        sr_b = random.choice(sampling_rates)
+        in_bs = random.choice(buffer_sizes)
+
+        resampler.set_sample_rates(sr_a, sr_b, in_bs)
+        out_bs = resampler.out_bs
+
+        # Check inplace resampler internal values are correct for matching the first sample
+        assert resampler.x_in[0] == 0.0
+        assert resampler.x_in[-1] == 0.0 or resampler.x_in[-1] == 1.0
+
+        # Check process_in()
+        in_audio = tr.rand((in_n_ch, in_bs))
+        in_resampled = resampler.process_in(in_audio)
+        assert in_resampled.size(0) == in_n_ch
+        # Check that the first sample is equal to the input audio
+        assert tr.equal(in_resampled[:, 0], in_audio[:, 0])
+        # Check that the last sample is reasonably close to the input audio
+        assert tr.allclose(in_resampled[:, -1], in_audio[:, -1], atol=1e-3)
+
+        # Check the 4p cubic hermite spline calculation element-wise
+        x = resampler.x_in
+        y_m1 = tr.index_select(in_audio, dim=1, index=resampler.y_m1_idx_in)
+        y0 = tr.index_select(in_audio, dim=1, index=resampler.y0_idx_in)
+        y1 = tr.index_select(in_audio, dim=1, index=resampler.y1_idx_in)
+        y2 = tr.index_select(in_audio, dim=1, index=resampler.y2_idx_in)
+
+        for ch_idx in range(in_n_ch):
+            for x_idx in range(out_bs):
+                y_calc = _calc_4p_hermite(x[x_idx],
+                                          y_m1[ch_idx, x_idx],
+                                          y0[ch_idx, x_idx],
+                                          y1[ch_idx, x_idx],
+                                          y2[ch_idx, x_idx])
+                assert math.isclose(y_calc, in_resampled[ch_idx, x_idx], abs_tol=1e-6)
+
+        # TODO(cm): remove duplication
+        # Check process_out()
+        out_audio = tr.rand((out_n_ch, out_bs))
+        out_resampled = resampler.process_out(out_audio)
+        assert out_resampled.size(0) == out_n_ch
+        # Check that the first sample is equal to the input audio
+        assert tr.equal(out_resampled[:, 0], out_audio[:, 0])
+        # Check that the last sample is reasonably close to the input audio
+        assert tr.allclose(out_resampled[:, -1], out_audio[:, -1], atol=1e-3)
+
+        # Check the 4p cubic hermite spline calculation element-wise
+        x = resampler.x_out
+        y_m1 = tr.index_select(out_audio, dim=1, index=resampler.y_m1_idx_out)
+        y0 = tr.index_select(out_audio, dim=1, index=resampler.y0_idx_out)
+        y1 = tr.index_select(out_audio, dim=1, index=resampler.y1_idx_out)
+        y2 = tr.index_select(out_audio, dim=1, index=resampler.y2_idx_out)
+
+        for ch_idx in range(out_n_ch):
+            for x_idx in range(in_bs):
+                y_calc = _calc_4p_hermite(x[x_idx],
+                                          y_m1[ch_idx, x_idx],
+                                          y0[ch_idx, x_idx],
+                                          y1[ch_idx, x_idx],
+                                          y2[ch_idx, x_idx])
+                assert math.isclose(y_calc, out_resampled[ch_idx, x_idx], abs_tol=1e-6)

--- a/testing/test_sandwiches.py
+++ b/testing/test_sandwiches.py
@@ -6,7 +6,7 @@ import torch as tr
 import torch.nn.functional as F
 from tqdm import tqdm
 
-from neutone_sdk.sandwich import InterpolationResampler, InplaceInterpolationResampler
+from neutone_sdk.sandwich import InterpolationResampler, InplaceLinearResampler
 
 logging.basicConfig()
 log = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ def test_interpolation_resamplers(in_n_ch: int = 2, out_n_ch: int = 2) -> None:
     trials = 1000
 
     resampler = InterpolationResampler(48000, 48000, 512)
-    inplace_resampler = InplaceInterpolationResampler(
+    inplace_resampler = InplaceLinearResampler(
         in_n_ch, out_n_ch, 48000, 48000, 512
     )
 

--- a/testing/test_sandwiches.py
+++ b/testing/test_sandwiches.py
@@ -6,54 +6,70 @@ import torch as tr
 import torch.nn.functional as F
 from tqdm import tqdm
 
-from neutone_sdk.sandwich import InterpolationResampler, InplaceLinearResampler
+from neutone_sdk.sandwich import LinearResampler, InplaceLinearResampler, Inplace4pHermiteResampler
 
 logging.basicConfig()
 log = logging.getLogger(__name__)
 log.setLevel(level=os.environ.get("LOGLEVEL", "INFO"))
 
 
-def test_interpolation_resamplers(in_n_ch: int = 2, out_n_ch: int = 2) -> None:
+def test_linear_resamplers(n_trials: int = 1000, in_n_ch: int = 2, out_n_ch: int = 2) -> None:
     random.seed(42)
     tr.manual_seed(42)
     sampling_rates = [16000, 22050, 32000, 44100, 48000, 88200, 96000]
     buffer_sizes = [64, 128, 256, 512, 1024, 2048]
-    trials = 1000
 
-    resampler = InterpolationResampler(48000, 48000, 512)
+    resampler = LinearResampler(48000, 48000, 512)
     inplace_resampler = InplaceLinearResampler(
         in_n_ch, out_n_ch, 48000, 48000, 512
     )
 
-    for _ in tqdm(range(trials)):
+    for _ in tqdm(range(n_trials)):
         sr_a = random.choice(sampling_rates)
         sr_b = random.choice(sampling_rates)
         in_bs = random.choice(buffer_sizes)
 
         resampler.set_sample_rates(sr_a, sr_b, in_bs)
         inplace_resampler.set_sample_rates(sr_a, sr_b, in_bs)
+        # Check inplace linear resampler internal values are correct for matching the ends exactly
+        assert inplace_resampler.x_in[0] == 0.0
+        assert inplace_resampler.x_in[-1] == 0.0 or inplace_resampler.x_in[-1] == 1.0
 
         in_audio = tr.rand((in_n_ch, in_bs))
-        resampled_1 = resampler.process_in(in_audio)
-        resampled_2 = inplace_resampler.process_in(in_audio)
-        out_bs = resampled_1.size(1)
-        assert resampled_1.shape == resampled_2.shape
-        assert tr.allclose(resampled_1, resampled_2, atol=1e-5)
-        resampled_3 = F.interpolate(
+        in_linear = resampler.process_in(in_audio)
+        in_linear_inplace = inplace_resampler.process_in(in_audio)
+        out_bs = in_linear.size(1)
+        assert in_linear.shape == in_linear_inplace.shape
+
+        # PyTorch interpolation does not match the ends exactly, hence two asserts
+        assert tr.allclose(in_linear[:, 1:-1], in_linear_inplace[:, 1:-1], atol=1e-6)
+        assert tr.allclose(in_linear[:, [0, -1]], in_linear_inplace[:, [0, -1]], atol=1e-3)
+        in_interpolated = F.interpolate(
             in_audio.unsqueeze(0), out_bs, mode="linear", align_corners=True
         ).squeeze(0)
-        assert tr.allclose(resampled_1, resampled_3, atol=1e-5)
+        # PyTorch interpolation does not match the ends exactly, hence two asserts
+        assert tr.allclose(in_linear_inplace[:, 1:-1], in_interpolated[:, 1:-1], atol=1e-6)
+        assert tr.allclose(in_linear_inplace[:, [0, -1]], in_interpolated[:, [0, -1]], atol=1e-3)
+        # Check that the ends match exactly
+        assert tr.equal(in_linear_inplace[:, [0, -1]], in_audio[:, [0, -1]])
 
         out_audio = tr.rand((out_n_ch, out_bs))
-        resampled_1 = resampler.process_out(out_audio)
-        resampled_2 = inplace_resampler.process_out(out_audio)
-        assert resampled_1.shape == resampled_2.shape
-        assert resampled_1.size(1) == in_bs
-        assert tr.allclose(resampled_1, resampled_2, atol=1e-5)
-        resampled_3 = F.interpolate(
+        out_linear = resampler.process_out(out_audio)
+        out_linear_inplace = inplace_resampler.process_out(out_audio)
+        assert out_linear.shape == out_linear_inplace.shape
+        assert out_linear.size(1) == in_bs
+
+        # PyTorch interpolation does not match the ends exactly, hence two asserts
+        assert tr.allclose(out_linear[:, 1:-1], out_linear_inplace[:, 1:-1], atol=1e-6)
+        assert tr.allclose(out_linear[:, [0, -1]], out_linear_inplace[:, [0, -1]], atol=1e-3)
+        out_interpolated = F.interpolate(
             out_audio.unsqueeze(0), in_bs, mode="linear", align_corners=True
         ).squeeze(0)
-        assert tr.allclose(resampled_1, resampled_3, atol=1e-5)
+        # PyTorch interpolation does not match the ends exactly, hence two asserts
+        assert tr.allclose(out_linear_inplace[:, 1:-1], out_interpolated[:, 1:-1], atol=1e-6)
+        assert tr.allclose(out_linear_inplace[:, [0, -1]], out_interpolated[:, [0, -1]], atol=1e-3)
+        # Check that the ends match exactly
+        assert tr.equal(out_linear_inplace[:, [0, -1]], out_audio[:, [0, -1]])
 
 
-test_interpolation_resamplers()
+test_linear_resamplers()

--- a/testing/test_sandwiches.py
+++ b/testing/test_sandwiches.py
@@ -54,3 +54,6 @@ def test_interpolation_resamplers(in_n_ch: int = 2, out_n_ch: int = 2) -> None:
             out_audio.unsqueeze(0), in_bs, mode="linear", align_corners=True
         ).squeeze(0)
         assert tr.allclose(resampled_1, resampled_3, atol=1e-5)
+
+
+test_interpolation_resamplers()


### PR DESCRIPTION
This PR adds a 4-point cubic hermite spline interpolation for better resampling.

The implementation is taken from "Polynomial Interpolators for High-Quality Resampling of Oversampled Audio" by Olli Niemitalo (http://yehar.com/blog/wp-content/uploads/2009/08/deip.pdf).
Does not dynamically allocate memory and is only ~2x slower than the `InplaceLinearResampler`. For comparison, sinc interpolation is ~4.5x slower and requires dynamic memory allocations.

The 2nd, -2nd, and sometimes -1st samples will be slightly off since this interpolator requires 4 points, but we assume a repeated sample when these are not available at the ends rather than adding 2-samples of delay. The 0th sample is always the same as the original audio since its corresponding x value is always 0.

From some experiments in Ableton, the spectrum shows about ~20 dB of improvement for a single sine tone going from 44.1 to 48 kHz at 2048 buffer size. From the frequency response of the hermite interpolator compared to the linear interpolater, we should see ~3 dB improvement in attenuation in the higher frequencies above 10 kHz.

44.1 kHz to 48 kHz (previous linear interpolator)
![44_to_48_linear](https://github.com/QosmoInc/neutone_sdk/assets/6411612/f5cf0461-02dc-4fbe-bd08-fe4d8b6a9ca7)

44.1 kHz to 48 kHz (hermite interpolator)
![44_to_48_hermite](https://github.com/QosmoInc/neutone_sdk/assets/6411612/225d2fd9-b3a4-4ed7-a7eb-3f08aacc372c)

88.2 kHz to 48 kHz (previous linear interpolator)
![88_to_48_linear](https://github.com/QosmoInc/neutone_sdk/assets/6411612/d2187af1-55b4-439e-88e1-6a9fb9ae2e7e)

88.2 kHz to 48 kHz (hermite interpolator)
![88_to_48_hermite](https://github.com/QosmoInc/neutone_sdk/assets/6411612/86d7cb3f-fb7a-4dbd-b0bd-e9038487ebc2)

cc: @Fyfe93 